### PR TITLE
Fix HTTP client timeout configuration

### DIFF
--- a/client.go
+++ b/client.go
@@ -96,10 +96,13 @@ func NewClient(config *Config) (*Client, error) {
 	}
 
 	// Configure HTTP client with custom timeout
-	httpClient := &http.Client{
-		Timeout: config.Timeout,
+	// Only set custom HTTP client if timeout is configured, otherwise use default
+	if config.Timeout > 0 {
+		httpClient := &http.Client{
+			Timeout: config.Timeout,
+		}
+		apiConfig.HTTPClient = httpClient
 	}
-	apiConfig.HTTPClient = httpClient
 
 	// Create API client
 	apiClient := api.NewAPIClient(apiConfig)

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package daytona
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -93,6 +94,12 @@ func NewClient(config *Config) (*Client, error) {
 	if config.OrgID != "" {
 		apiConfig.AddDefaultHeader("X-Daytona-Organization-ID", config.OrgID)
 	}
+
+	// Configure HTTP client with custom timeout
+	httpClient := &http.Client{
+		Timeout: config.Timeout,
+	}
+	apiConfig.HTTPClient = httpClient
 
 	// Create API client
 	apiClient := api.NewAPIClient(apiConfig)


### PR DESCRIPTION
The SDK was not properly applying the configured timeout to the HTTP client, causing requests to timeout at the default HTTP client timeout (or proxy/gateway timeouts) instead of respecting the configured timeout value.

This fix:
- Adds net/http import
- Creates a custom HTTP client with the configured timeout
- Applies the custom HTTP client to the API configuration

This ensures that long-running commands respect the timeout specified in the Config struct, preventing premature timeouts for operations that legitimately need more time to complete.

🤖 Generated with [Claude Code](https://claude.ai/code)